### PR TITLE
Fix provider connect template strings

### DIFF
--- a/src/app/onboarding/connect/[provider]/page.tsx
+++ b/src/app/onboarding/connect/[provider]/page.tsx
@@ -14,6 +14,7 @@ interface ConnectPageProps {
   }
 }
 
+
 export default function ConnectPage({ params }: ConnectPageProps) {
   const router = useRouter()
   const [isConnecting, setIsConnecting] = useState(false)
@@ -46,9 +47,9 @@ export default function ConnectPage({ params }: ConnectPageProps) {
       <div className="text-center space-y-2">
         <h2 className="text-xl font-semibold">Connect {provider.name}</h2>
         <p className="text-muted-foreground">
-          {provider.oauthSupported 
-            ? 'We'll securely connect to your account'
-            : 'We'll hook this up later - for now, let's continue'
+          {provider.oauthSupported
+            ? "We'll securely connect to your account"
+            : "We'll hook this up later - for now, let's continue"
           }
         </p>
       </div>


### PR DESCRIPTION
## Summary
- use double-quoted strings in the provider connect template so apostrophes no longer break the build

## Testing
- npm run build *(fails: network restriction prevents fetching Inter font)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c8093dd8832c9f1ec17994065681